### PR TITLE
Point to GlobalScope functions in Evaluating Expressions

### DIFF
--- a/tutorials/scripting/evaluating_expressions.rst
+++ b/tutorials/scripting/evaluating_expressions.rst
@@ -198,7 +198,7 @@ The output from the script will be::
 Built-in functions
 ------------------
 
-Most methods available in the :ref:`class_@GDScript` scope are available in the
+All methods in the :ref:`class_@GlobalScope` are available in the
 Expression class, even if no base instance is bound to the expression.
 The same parameters and return types are available.
 


### PR DESCRIPTION
Update for 4.x since builtin functions were moved to GlobalScope.
https://docs.godotengine.org/en/4.1/tutorials/scripting/evaluating_expressions.html#built-in-functions